### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Then a `gypkg` CLI tool can be used to build a project (NOTE: while [`ninja`][5]
 is not necessary, it is recommended for fast incremental builds):
 
 ```bash
-gypkg build file.gyp -- -Duv_library=static-library
+gypkg build file.gyp -- -Duv_library=static_library
 ```
 
 `build` command will install all dependencies into `gypkg_deps` and will update


### PR DESCRIPTION
Fixes:

```
$ gypkg build build.gyp -- -Duv_library=static-library
...
Error: Target gypkg_deps/libuv/libuv@semver-05870e6/uv.gyp:libuv#target has an invalid target type 'static-library.  Must be on of executable/loadable_module/static_library/shared_library/mac_kernel_extension/none.
```